### PR TITLE
use jsdelivr CDN for vue.js development version

### DIFF
--- a/app/helpers/syntax_helper.rb
+++ b/app/helpers/syntax_helper.rb
@@ -3,8 +3,8 @@ module SyntaxHelper
     " #{controller_name} #{action_name} "
   end
 
-  def vue_include_tag(version)
-    javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/vue/#{version}/vue.js" if Rails.env.development?
+  def vue_include_tag
+    javascript_include_tag "https://cdn.jsdelivr.net/npm/vue/dist/vue.js" if Rails.env.development?
   end
 
   def rails_version


### PR DESCRIPTION
* use jsdelivr for vue.js development version
* to align with the cdn suggested by vuejs
  * https://vuejs.org/v2/guide/#Getting-Started
  * See https://www.jsdelivr.com/ for naming convention

💬 To be discussed… What do you think?